### PR TITLE
Fix Intune export crash when tenant has no matching configuration policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,7 @@
 * M365DSCReverse
   * Fixed an issue where exporting the Intune workload against a tenant with no
     matching Settings Catalog configuration policies aborted the entire export
-    with `Object reference not set to an instance of an object`. Casting an empty
-    pipeline to `[array]` yields `$null`, which was passed to
-    `ConfigurationPolicyCache.Populate`.
+    with `Object reference not set to an instance of an object`.
     FIXES [#7396](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7396)
 * M365DSCTenantInfo
   * Added support for Bleu and Delos sovereign cloud.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 # UNRELEASED
 
+* M365DSCReverse
+  * Fixed an issue where exporting the Intune workload against a tenant with no
+    matching Settings Catalog configuration policies aborted the entire export
+    with `Object reference not set to an instance of an object`. Casting an empty
+    pipeline to `[array]` yields `$null`, which was passed to
+    `ConfigurationPolicyCache.Populate`.
+    FIXES [#7396](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7396)
 * M365DSCTenantInfo
   * Added support for Bleu and Delos sovereign cloud.
 * DEPENDENCIES

--- a/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
@@ -907,9 +907,7 @@ function Start-M365DSCConfigurationExtract
                 ManagedIdentity = $ManagedIdentity
                 AccessTokens = $AccessTokens
             }
-            # @() is required: casting a pipeline that emitted nothing to [array] yields $null, not an
-            # empty array, which would then be passed to ConfigurationPolicyCache::Populate.
-            [array]$allRequestedConfigurationPolicies = @(Get-MgBetaDeviceManagementConfigurationPolicy -All | Where-Object { $_.templateReference.templateId -in $requestedConfigurationPolicyTemplateIds })
+            $allRequestedConfigurationPolicies = Get-M365DSCArrayFromProperty -PropertyValue (Get-MgBetaDeviceManagementConfigurationPolicy -All | Where-Object { $_.templateReference.templateId -in $requestedConfigurationPolicyTemplateIds })
             $batchRequests = @()
             foreach ($policy in $allRequestedConfigurationPolicies)
             {

--- a/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
@@ -907,7 +907,9 @@ function Start-M365DSCConfigurationExtract
                 ManagedIdentity = $ManagedIdentity
                 AccessTokens = $AccessTokens
             }
-            [array]$allRequestedConfigurationPolicies = Get-MgBetaDeviceManagementConfigurationPolicy -All | Where-Object { $_.templateReference.templateId -in $requestedConfigurationPolicyTemplateIds }
+            # @() is required: casting a pipeline that emitted nothing to [array] yields $null, not an
+            # empty array, which would then be passed to ConfigurationPolicyCache::Populate.
+            [array]$allRequestedConfigurationPolicies = @(Get-MgBetaDeviceManagementConfigurationPolicy -All | Where-Object { $_.templateReference.templateId -in $requestedConfigurationPolicyTemplateIds })
             $batchRequests = @()
             foreach ($policy in $allRequestedConfigurationPolicies)
             {

--- a/src/Microsoft365DSC.Intune/ConfigurationPolicyCache.cs
+++ b/src/Microsoft365DSC.Intune/ConfigurationPolicyCache.cs
@@ -20,9 +20,7 @@ namespace Microsoft365DSC.Intune
                 if (_isPopulated)
                     return;
 
-                // A tenant with no matching configuration policies yields a null collection from
-                // the caller, which is a populated-but-empty cache rather than an error.
-                if (allPolicies == null)
+                if (allPolicies is null)
                 {
                     _isPopulated = true;
                     return;

--- a/src/Microsoft365DSC.Intune/ConfigurationPolicyCache.cs
+++ b/src/Microsoft365DSC.Intune/ConfigurationPolicyCache.cs
@@ -20,6 +20,14 @@ namespace Microsoft365DSC.Intune
                 if (_isPopulated)
                     return;
 
+                // A tenant with no matching configuration policies yields a null collection from
+                // the caller, which is a populated-but-empty cache rather than an error.
+                if (allPolicies == null)
+                {
+                    _isPopulated = true;
+                    return;
+                }
+
                 foreach (var policy in allPolicies)
                 {
                     string templateId = templateIdSelector(policy);


### PR DESCRIPTION

#### Pull Request (PR) description

Exporting the Intune workload aborts before any resource is extracted, with
`Exception calling "Populate" with "2" argument(s): "Object reference not set to an instance of an object."`,
on tenants that have no Settings Catalog configuration policies matching the requested template IDs.

`M365DSCReverse.psm1:910` casts a filtered pipeline to `[array]`. When that pipeline emits nothing the
result is `$null`, not an empty array:

```powershell
PS> [array]$x = @() | Where-Object { $_ -eq 'nothing' }
PS> $null -eq $x
True
```

The `$null` reaches `ConfigurationPolicyCache.Populate` at line 927, whose `foreach` dereferences it. As
this runs in the pre-pass of `Start-M365DSCConfigurationExtract`, the whole workload is lost rather than a
single resource, and nothing is written to the M365DSC error log.

Changes:

* `ConfigurationPolicyCache.Populate` now treats a null collection as a populated-but-empty cache. This is
  the correct semantic rather than merely defensive: `GetByTemplateId` returns `null` for a miss, and
  `M365DSCIntuneUtil.psm1:528-533` already falls back to a live filtered Graph query, which is the right
  result for a tenant with no policies.
* `M365DSCReverse.psm1:910` wraps the pipeline in `@()` so the caller produces an empty array. Belt and
  braces — either change alone fixes the crash.

Verified against the built assembly: `Populate($null, selector)` no longer throws, `GetByTemplateId`
returns `null` so consumers take the fallback path, and a non-null collection still caches as before.
Also verified end to end by exporting `IntuneFirewallPolicyWindows10`, `IntuneSecurityBaselineWindows10`
and `IntuneDeviceCategory` against a zero-policy tenant: 3/3 successful where the export previously died
before resource 1.

#### This Pull Request (PR) fixes the following issues

- Fixes #7396

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!--
Unticked items are not applicable: this changes export framework code and a compiled helper, not a DSC
resource, so there is no schema.mof, README, settings.json or example to update. There is no existing
test project for src/Microsoft365DSC.Intune; happy to add one if a maintainer would like it.
-->
