### PR TITLE
AADAuthenticationMethodPolicy: Documentation-only update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Change log for Microsoft365DSC
 
-# Unreleased
+# UNRELEASED
 
 * AADAuthenticationMethodPolicy
-  * Update schema to indicate additional support for Passkeys (FIDO2) as the target of a registrationcampaign
-    TargetedAuthenticationMethod can now contain 'microsoftAuthenticator' *or* 'fido2'
+  * Added additional support for Passkeys (FIDO2) as the target of a registrationcampaign.
+    `TargetedAuthenticationMethod` can now contain `microsoftAuthenticator` *or* `fido2`.
 
 # 1.26.812.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log for Microsoft365DSC
 
+# Unreleased
+
+* AADAuthenticationMethodPolicy
+  * Update schema to indicate additional support for Passkeys (FIDO2) as the target of a registrationcampaign
+    TargetedAuthenticationMethod can now contain 'microsoftAuthenticator' *or* 'fido2'
+
 # 1.26.812.1
 
 * M365DSCTenantInfo

--- a/Modules/Microsoft365DSC/DscResources/MSFT_AADAuthenticationMethodPolicy/MSFT_AADAuthenticationMethodPolicy.schema.mof
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_AADAuthenticationMethodPolicy/MSFT_AADAuthenticationMethodPolicy.schema.mof
@@ -34,11 +34,11 @@ class MSFT_MicrosoftGraphExcludeTarget
     [Key, Description("The type of the authentication method target. Possible values are: user, group, unknownFutureValue."), ValueMap{"user","group","unknownFutureValue"}, Values{"user","group","unknownFutureValue"}] String TargetType;
 };
 
-[ClassVersion("1.0.0.1")]
+[ClassVersion("1.0.0.2")]
 class MSFT_MicrosoftGraphAuthenticationMethodsRegistrationCampaignIncludeTarget
 {
     [Key, Description("The object identifier of an Azure AD user or group.")] String Id;
-    [Required, Description("The authentication method that the user is prompted to register. The value must be microsoftAuthenticator or fido2.")] String TargetedAuthenticationMethod;
+    [Required, Description("The authentication method that the user is prompted to register. The value can be Fido2 or microsoftAuthenticator."), ValueMap{"microsoftAuthenticator","Fido2"}, Values{"microsoftAuthenticator","Fido2"}] String TargetedAuthenticationMethod;
     [Key, Description("The type of the authentication method target. Possible values are: user, group, unknownFutureValue."), ValueMap{"user","group","unknownFutureValue"}, Values{"user","group","unknownFutureValue"}] String TargetType;
 };
 

--- a/Modules/Microsoft365DSC/DscResources/MSFT_AADAuthenticationMethodPolicy/MSFT_AADAuthenticationMethodPolicy.schema.mof
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_AADAuthenticationMethodPolicy/MSFT_AADAuthenticationMethodPolicy.schema.mof
@@ -38,7 +38,7 @@ class MSFT_MicrosoftGraphExcludeTarget
 class MSFT_MicrosoftGraphAuthenticationMethodsRegistrationCampaignIncludeTarget
 {
     [Key, Description("The object identifier of an Azure AD user or group.")] String Id;
-    [Required, Description("The authentication method that the user is prompted to register. The value must be microsoftAuthenticator.")] String TargetedAuthenticationMethod;
+    [Required, Description("The authentication method that the user is prompted to register. The value must be microsoftAuthenticator or fido2.")] String TargetedAuthenticationMethod;
     [Key, Description("The type of the authentication method target. Possible values are: user, group, unknownFutureValue."), ValueMap{"user","group","unknownFutureValue"}, Values{"user","group","unknownFutureValue"}] String TargetType;
 };
 


### PR DESCRIPTION
AADAuthenticationMethodPolicy can also target registration-campaigns for Passkeys (FIDO2) in addition to Microsoft Authenticator

#### Pull Request (PR) description
The schema for the resource contains an updated description for TargetedAuthenticationMethod

#### This Pull Request (PR) fixes the following issues
None

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
