### PR TITLE
feat: Add RSS feed to blog

### DIFF
--- a/.github/workflows/PublishGitHubPages.yml
+++ b/.github/workflows/PublishGitHubPages.yml
@@ -58,6 +58,7 @@ jobs:
       - run: |
           pip install mkdocs-material
           pip install mkdocs-include-dir-to-nav
+          pip install mkdocs-rss-plugin
 
       - name: Download generated docs
         uses: actions/download-artifact@v7

--- a/docs/docs/blog/2024/dsc-error-flow/dsc-error-flow.md
+++ b/docs/docs/blog/2024/dsc-error-flow/dsc-error-flow.md
@@ -1,3 +1,7 @@
+---
+date: 2024-06-28
+---
+
 # Deep-Dive into the Local Configuration Manager (LCM) Error Flow
 
 <img src="../../../images/NikCharlebois.jpg" style="width:75px;border-radius:50%;border:3px solid black;float:left;" />

--- a/docs/docs/blog/2026/docker-images/docker-images.md
+++ b/docs/docs/blog/2026/docker-images/docker-images.md
@@ -1,3 +1,7 @@
+---
+date: 2026-07-09
+---
+
 # Microsoft365DSC Docker Images: How to Use Them
 
 <img src="../../../images/FabienTschanz.jpg" style="width:75px;border-radius:50%;border:3px solid black;float:left;" />

--- a/docs/docs/blog/2026/intune-settings-catalog/intune-settings-catalog.md
+++ b/docs/docs/blog/2026/intune-settings-catalog/intune-settings-catalog.md
@@ -1,3 +1,7 @@
+---
+date: 2026-04-11
+---
+
 # Intune Settings Catalog in Microsoft365DSC
 
 <img src="../../../images/FabienTschanz.jpg" style="width:75px;border-radius:50%;border:3px solid black;float:left;" />

--- a/docs/docs/blog/2026/performance-improvements/performance-improvements.md
+++ b/docs/docs/blog/2026/performance-improvements/performance-improvements.md
@@ -1,3 +1,7 @@
+---
+date: 2026-07-23
+---
+
 # Under the Hood: How We Make Microsoft365DSC Exports Faster
 
 <img src="../../../images/FabienTschanz.jpg" style="width:75px;border-radius:50%;border:3px solid black;float:left;" />

--- a/docs/docs/blog/2026/utcm-transition/utcm-transition.md
+++ b/docs/docs/blog/2026/utcm-transition/utcm-transition.md
@@ -1,3 +1,7 @@
+---
+date: 2026-01-27
+---
+
 # Moving from Microsoft365DSC to Tenant Configuration Management APIs
 
 Microsoft recently announced the public preview of the [Tenant Configuration Management APIs (TCM)](https://learn.microsoft.com/en-us/graph/unified-tenant-configuration-management-concept-overview). TCM is an official solution that is supported by Microsoft, which offers the same high-level features as Microsoft365DSC. During the preview phase, only the configuration export/snapshot and the drift detection/monitoring  features are available. The ability to push configuration changes and to remediate to detected drifts will be made available later. The APIs are hosted on the Microsoft Graph, which means you can either access them directly via REST calls, or leverage the Microsoft Graph SDKs such as the Graph .NET SDK, the Graph Java SDK, or Graph PowerShell SDK to interact with them. It is important to note that because these are available on the Graph APIs, you are no longer tied to and forced to use PowerShell to automate your tenant configuration management tasks.

--- a/docs/docs/blog/april-2023-major-release.md
+++ b/docs/docs/blog/april-2023-major-release.md
@@ -1,3 +1,7 @@
+---
+date: 2023-03-27
+---
+
 # Microsoft365DSC – April 2023 Major Release (version 1.23.405.1)
 
 As defined by our [Breaking Changes Policy](https://microsoft365dsc.com/concepts/breaking-changes/), twice a year we allow for breaking changes to be deployed as part of a release. Our next major release, scheduled to go out on April 5th 2023, will include several breaking changes and will be labeled version 1.23.405.1. This article provides details on the breaking changes and other important updates that will be included as part of our April 2023 Major release.

--- a/docs/docs/blog/april-2024-major-release.md
+++ b/docs/docs/blog/april-2024-major-release.md
@@ -1,3 +1,7 @@
+---
+date: 2024-03-27
+---
+
 # Microsoft365DSC – April 2024 Major Release (version 1.24.403.1)
 
 As defined by our [Breaking Changes Policy](https://microsoft365dsc.com/concepts/breaking-changes/), twice a year we allow for breaking changes to be deployed as part of a release. Our next major release, scheduled to go out on April 3rd 2024, will include several breaking changes and will be labeled version 1.24.403.1. This article provides details on the breaking changes and other important updates that will be included as part of our April 2024 Major release.

--- a/docs/docs/blog/april-2025-major-release.md
+++ b/docs/docs/blog/april-2025-major-release.md
@@ -1,3 +1,7 @@
+---
+date: 2025-03-28
+---
+
 # Microsoft365DSC – April 2025 Major Release (version 1.25.402.1)
 
 As defined by our [Breaking Changes Policy](https://microsoft365dsc.com/concepts/breaking-changes/), twice a year we allow for breaking changes to be deployed as part of a release. Our next major release, scheduled to go out on April 2nd 2025, will include several breaking changes and will be labeled version 1.25.402.1. This article provides details on the breaking changes and other important updates that will be included as part of our April 2025 Major release.

--- a/docs/docs/blog/october-2022-major-release.md
+++ b/docs/docs/blog/october-2022-major-release.md
@@ -1,3 +1,7 @@
+---
+date: 2022-09-30
+---
+
 # Microsoft365DSC – October 2022 Major Release (version 1.22.1005.1)
 
 As defined by our [Breaking Changes Policy](https://microsoft365dsc.com/concepts/breaking-changes/), twice a year we allow for breaking changes to be deployed as part of a release. Next week’s release, scheduled to go out on October 5th 2022, will include several breaking changes and will be labeled version 1.22.1005.1. This article provides details on the breaking changes that will be included as part of our October 2022 Major release.

--- a/docs/docs/blog/october-2023-major-release.md
+++ b/docs/docs/blog/october-2023-major-release.md
@@ -1,3 +1,7 @@
+---
+date: 2023-10-03
+---
+
 # Microsoft365DSC – October 2023 Major Release (version 1.23.1004.1)
 
 As defined by our [Breaking Changes Policy](https://microsoft365dsc.com/concepts/breaking-changes/), twice a year we allow for breaking changes to be deployed as part of a release. Our next major release, scheduled to go out on October 4th 2023, will include several breaking changes and will be labeled version 1.23.1004.1. This article provides details on the breaking changes and other important updates that will be included as part of our October 2023 Major release.

--- a/docs/docs/blog/october-2024-major-release.md
+++ b/docs/docs/blog/october-2024-major-release.md
@@ -1,3 +1,7 @@
+---
+date: 2024-10-02
+---
+
 # Microsoft365DSC – October 2024 Major Release (version 1.24.1002.1)
 
 As defined by our [Breaking Changes Policy](https://microsoft365dsc.com/concepts/breaking-changes/), twice a year we allow for breaking changes to be deployed as part of a release. Our next major release, scheduled to go out on October 2nd 2024, will include several breaking changes and will be labeled version 1.24.1002.1. This article provides details on the breaking changes and other important updates that will be included as part of our October 2024 Major release.

--- a/docs/docs/blog/october-2025-major-release.md
+++ b/docs/docs/blog/october-2025-major-release.md
@@ -1,3 +1,7 @@
+---
+date: 2025-09-22
+---
+
 # Microsoft365DSC – October 2025 Major Release (version 1.25.1001.1)
 
 As defined by our [Breaking Changes Policy](https://microsoft365dsc.com/concepts/breaking-changes/), twice a year we allow for breaking changes to be deployed as part of a release. Our next major release, scheduled to go out on October 21st 2025, will include several breaking changes and will be labeled version 1.25.1001.1. This article provides details on the breaking changes and other important updates that will be included as part of our October 2025 Major release.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,5 +1,7 @@
 site_name: Microsoft365DSC - Your Cloud Configuration
 site_url: https://microsoft.github.io/Microsoft365DSC
+site_description: Manage and monitor your Microsoft 365 tenant configurations as code with Microsoft365DSC.
+site_author: Microsoft365DSC
 nav:
   - Home:
       - 'Introduction': 'index.md'
@@ -113,6 +115,12 @@ nav:
 plugins:
   - search
   - include_dir_to_nav
+  - rss:
+      match_path: 'blog/(?!index\.md).*'
+      use_git: false
+      date_from_meta:
+        as_creation: date
+      abstract_chars_count: 160
 theme:
   name: material
   custom_dir: docs/overrides
@@ -171,6 +179,8 @@ extra:
       link: 'https://www.youtube.com/channel/UCveScabVT6pxzqYgGRu17iw'
     - icon: fontawesome/solid/link
       link: 'https://www.powershellgallery.com/packages/Microsoft365DSC/'
+    - icon: fontawesome/solid/rss
+      link: 'https://microsoft.github.io/Microsoft365DSC/feed_rss_created.xml'
 extra_css:
   - stylesheets/extra.css
 repo_url: https://github.com/microsoft/Microsoft365DSC


### PR DESCRIPTION
#### Pull Request (PR) description

Adds an RSS feed to the documentation site using mkdocs-rss-plugin. Blog posts are stamped with their publication date via front matter (git history is unavailable in the deploy job), the plugin is installed in the GitHub Pages workflow, and an RSS icon is added to the site footer. The feed will be available at `https://microsoft.github.io/Microsoft365DSC/feed_rss_created.xml` and is auto-discoverable by feed readers.

#### This Pull Request (PR) fixes the following issues

Talked upon at: https://github.com/Microsoft365DSC/Microsoft365DSC/issues/6120

#### Task list

- [ ] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
