### PR TITLE
FIX #7403

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
   * Fixed an issue where exporting the Intune workload against a tenant with no
     matching Settings Catalog configuration policies aborted the entire export.
     FIXES [#7396](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7396)
+* SCDLPComplianceRule
+  * Fixed an issue where testing a missing rule with an advanced rule containing
+    ML model classifiers could fail before reporting drift.
+    FIXES [#7403](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7403)
 * MISC
   * Updated import warning that **PowerShell 7.6** is going to be required starting October 2026.
 

--- a/Modules/Microsoft365DSC/DscResources/MSFT_SCDLPComplianceRule/MSFT_SCDLPComplianceRule.psm1
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_SCDLPComplianceRule/MSFT_SCDLPComplianceRule.psm1
@@ -1427,7 +1427,7 @@ function Test-TargetResource
         $ValuesToCheck['EndpointDlpRestrictions'] = Convert-SCDLPEndpointDlpRestrictions -EndpointDlpRestrictions $ValuesToCheck['EndpointDlpRestrictions']
     }
 
-    if ($null -ne $ValuesToCheck['AdvancedRule'])
+    if ($null -ne $ValuesToCheck['AdvancedRule'] -and $CurrentValues.Ensure -eq 'Present')
     {
         $advancedRuleObject = $ValuesToCheck['AdvancedRule'] | ConvertFrom-Json | ConvertFrom-Json
         $conditions = @($advancedRuleObject.Condition)

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.SCDLPComplianceRule.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.SCDLPComplianceRule.Tests.ps1
@@ -387,6 +387,67 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             }
         }
 
+        Context -Name "Rule doesn't already exist but should with AdvancedRules containing trainable classifier ids" -Fixture {
+            BeforeAll {
+                $desiredAdvancedRule = @'
+{
+  "Version": "1.0",
+  "Condition": {
+    "Operator": "And",
+    "SubConditions": [
+      {
+        "ConditionName": "ContentContainsSensitiveInformation",
+        "Value": [
+          {
+            "Groups": [
+              {
+                "Name": "PHI SITs",
+                "Operator": "Or",
+                "Sensitivetypes": [
+                  {
+                    "Name": "Healthcare",
+                    "Id": "11111111-1111-1111-1111-111111111111",
+                    "Classifiertype": "MLModel"
+                  }
+                ]
+              }
+            ],
+            "Operator": "And"
+          }
+        ]
+      }
+    ]
+  }
+}
+'@
+                $testParams = @{
+                    Ensure       = 'Present'
+                    Policy       = 'MyParentPolicy'
+                    Comment      = 'New comment'
+                    AdvancedRule = $desiredAdvancedRule | ConvertTo-Json -Compress
+                    BlockAccess  = $False
+                    Name         = 'TestPolicy'
+                    Credential   = $Credential
+                }
+
+                $Script:AdvancedRulePassedToTest = $null
+                Mock -CommandName Get-DLPComplianceRule -MockWith {
+                    return $null
+                }
+
+                Mock -CommandName Test-M365DSCParameterState -MockWith {
+                    param($CurrentValues, $Source, $DesiredValues, $ValuesToCheck)
+                    $Script:AdvancedRulePassedToTest = $DesiredValues.AdvancedRule
+                    return $false
+                }
+            }
+
+            It 'Should not normalize AdvancedRules for missing rules' {
+                Test-TargetResource @testParams | Should -Be $false
+                $Script:AdvancedRulePassedToTest | Should -Be ($desiredAdvancedRule | ConvertTo-Json -Compress)
+            }
+        }
+
         Context -Name "Rule doesn't already exist but should with EndpointDlpRestrictions" -Fixture {
             BeforeAll {
                 $testParams = @{


### PR DESCRIPTION
#### Pull Request (PR) description
* SCDLPComplianceRule
  * Fixed an issue where testing a missing rule with an advanced rule containing
    ML model classifiers could fail before reporting drift.
    FIXES [#7403](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7403)


#### This Pull Request (PR) fixes the following issues
* FIXES #7403