### PR TITLE
Fixing handling for multiple Filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
     FIXES [#7403](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7403)
 * MISC
   * Updated import warning that **PowerShell 7.6** is going to be required starting October 2026.
+  * Fixed issue where using multiple Filters passes through empty filters to other exported resources
 
 # 1.26.812.1
 

--- a/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
@@ -851,7 +851,7 @@ function Start-M365DSCConfigurationExtract
 
                 Import-Module $resource.FullName -Force | Out-Null
                 $filterExists = (Get-Command 'Export-TargetResource').Parameters.Keys.Contains('Filter')
-                if ($filterExists -and $null -ne $using:Filters -and ($using:Filters).Keys.Contains($resourceName))
+                if ($filterExists -and $null -ne $using:Filters -and ($using:Filters).Keys.Contains($resourceName) -contains $true)
                 {
                     $resourceFilter = ($using:Filters).$resourceName
                     if ($filterExists)

--- a/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
@@ -851,9 +851,7 @@ function Start-M365DSCConfigurationExtract
 
                 Import-Module $resource.FullName -Force | Out-Null
                 $filterExists = (Get-Command 'Export-TargetResource').Parameters.Keys.Contains('Filter')
-                if ($filterExists -and `
-                        $null -ne $using:Filters -and `
-                        ($using:Filters).Keys.Where({ $_ -eq $resourceName }))
+                if ($filterExists -and $null -ne $using:Filters -and ($using:Filters).Keys.Where({ $_ -eq $resourceName }))
                 {
                     $resourceFilter = ($using:Filters).$resourceName
                     if ($filterExists)

--- a/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
@@ -851,7 +851,9 @@ function Start-M365DSCConfigurationExtract
 
                 Import-Module $resource.FullName -Force | Out-Null
                 $filterExists = (Get-Command 'Export-TargetResource').Parameters.Keys.Contains('Filter')
-                if ($filterExists -and $null -ne $using:Filters -and ($using:Filters).Keys.Contains($resourceName) -contains $true)
+                if ($filterExists -and `
+                        $null -ne $using:Filters -and `
+                        ($using:Filters).Keys.Contains($resourceName) -contains $true)
                 {
                     $resourceFilter = ($using:Filters).$resourceName
                     if ($filterExists)

--- a/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
@@ -853,7 +853,7 @@ function Start-M365DSCConfigurationExtract
                 $filterExists = (Get-Command 'Export-TargetResource').Parameters.Keys.Contains('Filter')
                 if ($filterExists -and `
                         $null -ne $using:Filters -and `
-                        ($using:Filters).Keys.Contains($resourceName) -contains $true)
+                        ($using:Filters).Keys.Where({ $_ -eq $resourceName }))
                 {
                     $resourceFilter = ($using:Filters).$resourceName
                     if ($filterExists)


### PR DESCRIPTION
#### Pull Request (PR) description
In DSC exports the `Filters` argument takes a hashtable of one or more pairs of Component x Filter.

Logic in M365DSCReverse.psm1 tries to only pass through a Filter if it matches the resource currently being assessed (and if the resource itself can take a Filter).

The logic is very slightly skewiff meaning that, when multiple filters are passed in, an empty string gets passed through to the Export-TargetResource function for resources that were not intended to be filtered on.

i.e. 
```
Name                           Value
----                           -----
TeamsUserCallingSettings       UserPrincipalName -notlike '*#EXT#*'
TeamsOnlineVoicemailUserSetti… UserPrincipalName -notlike '*#EXT#*'
```
When an export is taken on `TeamsAIPolicy` with the above hashtable passed into `Filters`, the expected behaviour is that the Filter would be skipped for this resource however instead we get an empty string as the filter, and the below error occurs:
```
System.Management.Automation.ParameterBindingValidationException: Cannot validate argument on parameter 'Filter'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again.
```

The culprit is 
```ps1
if ($filterExists -and $null -ne $using:Filters -and ($using:Filters).Keys.Contains($resourceName))
```
Using the above example with `$resourceName = "TeamsAIPolicy"` and `$Filters` as described above, `($using:Filters).Keys.Contains($resourceName)` evaluates as `@(False, False)` due to it evaluating both keys. This object does not give the expected behaviour when combined with an `-and`, silently giving an error which counts as not `$null` hence `$true`.

As such the fix is to simply check if the returned object contains true. This has also been tested against Filters containing 1 row, or no Filters provided at all. This has been tested on PS5 and PS7.6.

The below commands can be used to test the raw behaviour:
```ps1
# Multiple Filters
[string[]]$FiltersString = "TeamsOnlineVoicemailUserSettings` =` UserPrincipalName` -notlike` `'*#EXT#*`'",  "TeamsUserCallingSettings` =` UserPrincipalName` -notlike` `'*#EXT#*`'"
$Filters = ConvertFrom-StringData -StringData ($FiltersString -join "`n")
$Filters.keys.contains("TeamsAI")
$Filters.keys.contains("TeamsAI").GetType() # object
$false -or $Filters.keys.contains("TeamsAI") # evaluates to true, suggesting the Contains is not the expected false
$Filters.keys.contains("TeamsAI") -contains $true # evaluates to false, fixing the issue
$Filters.keys.contains("TeamsOnlineVoicemailUserSettings") -contains $true # evaluates to true, so still works

# One Filter
[string[]]$FiltersString = "TeamsOnlineVoicemailUserSettings` =` UserPrincipalName` -notlike` `'*#EXT#*`'"
$Filters = ConvertFrom-StringData -StringData ($FiltersString -join "`n")
$Filters.keys.contains("TeamsAI")
$Filters.keys.contains("TeamsAI").GetType() # boolean
$false -or $Filters.keys.contains("TeamsAI") # evaluates to false, which is possibly why this has gone undetected until now
$Filters.keys.contains("TeamsAI") -contains $true # still evaluates to false, so the fix doesn't break anything
$Filters.keys.contains("TeamsOnlineVoicemailUserSettings") -contains $true # still evaluates to true, so the fix doesn't break anything
```

#### This Pull Request (PR) fixes the following issues
None

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take the time to run
    through the below checklist and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that applies to your PR. For those task that
    don't apply to you PR, leave those as is.
-->

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
