### PR TITLE
SPOSite: per-site lookup sits outside the try/catch, so one failure discards the resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* SPOSite
+  * Fixed an issue where a site collection that could not be retrieved aborted the entire export.
+
 # 1.26.819.1
 
 * AADAuthenticationMethodPolicy
@@ -36,9 +41,6 @@
   * Fixed an issue where testing a missing rule with an advanced rule containing
     ML model classifiers could fail before reporting drift.
     FIXES [#7403](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7403)
-* SPOSite
-  * Fixed an issue where a single site collection that could not be retrieved aborted
-    the export of the whole resource, discarding the site collections already exported.
 * MISC
   * Updated import warning that **PowerShell 7.6** is going to be required starting October 2026.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@
   * Fixed an issue where testing a missing rule with an advanced rule containing
     ML model classifiers could fail before reporting drift.
     FIXES [#7403](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7403)
+* SPOSite
+  * Fixed an issue where a single site collection that could not be retrieved aborted
+    the export of the whole resource, discarding the site collections already exported.
 * MISC
   * Updated import warning that **PowerShell 7.6** is going to be required starting October 2026.
 

--- a/Modules/Microsoft365DSC/DscResources/MSFT_SPOSite/MSFT_SPOSite.psm1
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_SPOSite/MSFT_SPOSite.psm1
@@ -942,32 +942,32 @@ function Export-TargetResource
             }
 
             Write-M365DSCHost -Message "    [$i/$($sites.Length)] $($site.Url)" -DeferWrite
-            $site = Get-PnPTenantSite -Identity $site.Url
-            $siteTitle = 'Null'
-            if (-not [System.String]::IsNullOrEmpty($site.Title))
-            {
-                $siteTitle = $site.Title
-            }
-
-            $Params = @{
-                Url                   = $site.Url
-                Template              = $site.Template
-                Owner                 = 'admin@contoso.com' # Passing in bogus value to bypass null owner error
-                Title                 = $siteTitle
-                TimeZoneId            = $site.TimeZoneID
-                ApplicationId         = $ApplicationId
-                TenantId              = $TenantId
-                ApplicationSecret     = $ApplicationSecret
-                CertificateThumbprint = $CertificateThumbprint
-                CertificatePath       = $CertificatePath
-                CertificatePassword   = $CertificatePassword
-                ManagedIdentity       = $ManagedIdentity.IsPresent
-                Credential            = $Credential
-                AccessTokens          = $AccessTokens
-            }
-
             try
             {
+                $site = Get-PnPTenantSite -Identity $site.Url -ErrorAction Stop
+                $siteTitle = 'Null'
+                if (-not [System.String]::IsNullOrEmpty($site.Title))
+                {
+                    $siteTitle = $site.Title
+                }
+
+                $Params = @{
+                    Url                   = $site.Url
+                    Template              = $site.Template
+                    Owner                 = 'admin@contoso.com' # Passing in bogus value to bypass null owner error
+                    Title                 = $siteTitle
+                    TimeZoneId            = $site.TimeZoneID
+                    ApplicationId         = $ApplicationId
+                    TenantId              = $TenantId
+                    ApplicationSecret     = $ApplicationSecret
+                    CertificateThumbprint = $CertificateThumbprint
+                    CertificatePath       = $CertificatePath
+                    CertificatePassword   = $CertificatePassword
+                    ManagedIdentity       = $ManagedIdentity.IsPresent
+                    Credential            = $Credential
+                    AccessTokens          = $AccessTokens
+                }
+
                 $Script:exportedInstance = $site
                 $Results = Get-TargetResource @Params
                 if ([System.String]::IsNullOrEmpty($Results.SharingDomainRestrictionMode))


### PR DESCRIPTION
#### Pull Request (PR) description

In `MSFT_SPOSite`'s `Export-TargetResource`, the per-site `Get-PnPTenantSite -Identity` call is the
only tenant call in the loop body that sits outside the `try` that follows it. When that call throws,
the exception leaves the loop and leaves the resource, so `Export-TargetResource` never returns. It is
caught by the per-resource `catch` in `M365DSCReverse.psm1` (885-893), which means line 881 —
`$exportString.Append($exportOutput)` — never runs, and every site collection the resource had already
collected is discarded along with the one that failed.

On a tenant with 36 site collections where a single lookup fails, the export writes **zero** `SPOSite`
blocks. The 35 sites that were retrieved without incident are lost with it. Nothing in the generated
`M365TenantConfig.ps1` records that a resource is missing, so the gap is only visible if you count the
blocks.

This PR moves the `try` above the per-site lookup so it covers the whole loop body, and adds
`-ErrorAction Stop` to that lookup to match the enumerating `Get-PnPTenantSite` call at line 917. One
site that cannot be read now costs that one site: the failure is reported on that site's own line with
the actual exception text, and the remaining sites still export.

This is containment, not a cure. Why the per-identity lookup fails on a PnP connection inherited from
an earlier resource is not established — see the last section of the details below.

<details>
<summary>How this was found — why the same failure costs either one site or all 36</summary>

Microsoft365DSC 1.26.805.2, unchanged. Business Premium tenant, app-only auth with a certificate,
PnP.PowerShell 1.12.0 reached from PowerShell 7.6.3 through the Windows PowerShell compatibility proxy.

## What I saw

A daily tenant export came back with a `SPOSite`-shaped hole in it. Not one `SPOSite` block in the
generated `M365TenantConfig.ps1` — one block is one exported site collection — while
`SPOSiteAuditSettings`, the next resource in the same export, wrote every one of its instances.

The log showed where it stopped:

```
    [1/36] https://<tenant>.sharepoint.com/✅
    [2/36] https://<tenant>.sharepoint.com/sites/-❌
An error occurred while exporting resource {SPOSite}: The Push Notifications feature is not
activated on the site "https://<tenant>-admin.sharepoint.com"
```

`Failed exports: {1}`. The resource enumerated 36 sites, exported the first one, failed on the second,
and wrote nothing at all — the site it had already collected went out with the failure.

Two things did not fit. The URL in the message is the tenant admin site, which is not in the
enumeration the loop walks. And the site it died on, `/sites/-`, answers fine when
`Get-PnPTenantSite -Identity` is called against it directly from Windows PowerShell 5.1.

pnp/powershell#4084 has the same string sitting next to a plain `401 Unauthorized`, so I read it as a
generic access or connection-context error rather than a feature check.

The module's own error log told me more than the message did:

```
{InvalidOperation}
System.Management.Automation.RemoteException: The Push Notifications feature is not activated ...
at <ScriptBlock><End>, ...\remoteIpMoProxy_PnPPowerShell_1.12.0_localhost_<guid>.psm1: line 31547
at Export-TargetResource, ...\MSFT_SPOSite.psm1: line 945
at Start-M365DSCConfigurationExtract, ...\M365DSCReverse.psm1: line 967
at Export-M365DSCConfiguration, ...\M365DSCExportUtil.psm1: line 427
```

The call goes through the compatibility proxy, so the failure arrives as a `RemoteException` written by
a generated proxy function.

## The same error, two different costs

Re-running it produced a second outcome. Same tenant, hours apart: 35 of 36 sites in the file,
`Failed exports: {0}`, the export reporting success, and a single yellow-circle line saying

```
🟡 Cannot bind argument to parameter 'Url' because it is an empty string.
```

That is not the same push-notifications error, it is the aftermath — when the failure does not
terminate, the assignment leaves `$site` as `$null` and the empty `Url` blows up downstream. The real
cause never reaches the log.

So the same failure costs either one site or all of them, depending on whether it terminates.

I found this by accident and it looked absurd: the same script, same parameters, same executable,
started with `pwsh -File` died and lost everything, started with `pwsh -Command "& script.ps1"` came
back with one site missing and called itself a success.

It depends on where the script's own `$ErrorActionPreference = 'Stop'` lands:

| Launch form | `$global:ErrorActionPreference` after that assignment |
| --- | --- |
| `-File script.ps1` | `Stop` |
| `-Command "& script.ps1"` | `Continue` |
| `-Command ". script.ps1"` | `Stop` |

With `-File`, the script is the global scope, so the assignment writes the global variable. With `&`,
the script gets a child scope and the assignment only shadows it.

That reaches the resource because `M365DSCReverse.psm1` line 875 passes `$ErrorActionPreference` into
`Export-TargetResource` as `-ErrorAction`, and a module function resolves that variable through local,
then module, then global scope — never the calling script's. So 875 reads the global value and hands it
to the resource, which is what decides whether the unguarded lookup throws.

## Constructing the outcomes on demand

Three runs, 36-site tenant, identical except for the launch form and one added assignment:

| # | Launch | `$global:ErrorActionPreference` | Blocks written | `Failed exports` |
| --- | --- | --- | --- | --- |
| A | `-File` | `Stop` | **0 of 36** | 1 |
| B | `-Command "& …"` | `Continue` | **35 of 36** | 0 |
| C | `-Command "& … -ForceGlobalStop"` | `Stop` | **0 of 36** | 1 |

C is the one that settles it. Same launch switch as B, one line added —
`$global:ErrorActionPreference = 'Stop'` — and the silent 35 turns back into a total loss.

## SPOSite on its own exports cleanly

Cutting the export down instead of varying how it starts:

```powershell
Export-M365DSCConfiguration -Components SPOSite -ApplicationId <id> `
    -CertificateThumbprint <thumbprint> -TenantId <tenant> -Path <out> -Mode Full
```

36 of 36 blocks, `/sites/-` exported like any other site, `Failed exports: {0}` — under `Stop` and
under `Continue` both. So it depends on whatever ran before `SPOSite` in the same process.

## It is an interaction between resources

Three SPO resources rebind the PnP connection inside their own `Export-TargetResource`, and none of
them puts it back. Resources export in alphabetical order, so all three come before `MSFT_SPOSite`:

| Resource | Rebinds the connection to |
| --- | --- |
| `MSFT_SPOApp` | the tenant app catalog (372) |
| `MSFT_SPOPropertyBag` | each site in turn (408) |
| `MSFT_SPOSearchManagedProperty` | `AdminUrl` (907) |

`MSFT_SPOSite` then connects at line 902 with no `-Url` at all, so it inherits whatever the last one
left behind. Narrowing it down:

| Configuration | Rebinder ran first | `Failed exports` | Blocks written |
| --- | --- | --- | --- |
| full `SPO` workload | yes | 1 | 0 of 36 |
| `-Components SPOPropertyBag,SPOSite` | yes | 1 | 0 of 36 |
| `-Components SPOSearchManagedProperty,SPOSite` | yes | 1 | 0 of 36 |
| `-Components SPOSearchManagedProperty,SPOSite`, `-Command` | yes | 0 | 35 of 36 |
| `-Components SPOSite` | no | 0 | 36 of 36 |

Either rebinder is enough on its own. `SPOSearchManagedProperty` has zero instances in this tenant and
still does it, which makes the third row the fastest reproducer.

## What is not established

The rebound connection is not simply broken. The enumeration at 917 works, and 35 of the 36
per-identity lookups work. Exactly one fails, in the same connection, every time. And
`SPOSearchManagedProperty` rebinds to the **admin URL** while `SPOSite`'s own connect at 902 resolves
to that same admin URL through the connection profile — same URL, opposite result.

Why that one lookup fails is unexplained, which is why this PR only stops one site's failure from
costing the resource.

</details>

#### This Pull Request (PR) fixes the following issues

None — no separate issue was filed. The investigation is in the description above.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
