### PR TITLE
Fix issue on Graph shim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   * Changed how an object is returned from Graph if both `value` and
     `presentation` properties are present, this fixes an issue on resource
     `IntuneDeviceConfigurationAdministrativeTemplatePolicyWindows10`
+* MISC
+  * Fixed build of Windows docker image
 
 # 1.26.826.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* M365DSCGraphShim
+  * Changed how an object is returned from Graph if both `value` and
+    `presentation` properties are present, this fixes an issue on resource
+    `IntuneDeviceConfigurationAdministrativeTemplatePolicyWindows10`
+
 # 1.26.826.1
 
 * AADRoleAssignmentScheduleRequest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 * M365DSCGraphShim
   * Changed how an object is returned from Graph if both `value` and
-    `presentation` properties are present, this fixes an issue on resource
-    `IntuneDeviceConfigurationAdministrativeTemplatePolicyWindows10`
+    `presentation` properties are present. This fixes an issue with the resource
+    `IntuneDeviceConfigurationAdministrativeTemplatePolicyWindows10`.
 * MISC
-  * Fixed build of Windows docker image
+  * Fixed an issue when building the Windows docker image.
 
 # 1.26.826.1
 

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -8,7 +8,7 @@ SHELL ["powershell", "-NoLogo"]
 
 RUN $null = Install-PackageProvider -Name "NuGet" -Force
 RUN $null = Install-Module -Name "Microsoft.PowerShell.PSResourceGet" -Repository "PSGallery" -Scope "AllUsers" -Force -SkipPublisherCheck
-RUN $null = Save-PSResource -Name "Microsoft365Dsc" -Repository "PSGallery" -Path "C:\Program Files\WindowsPowerShell\Modules" -SkipDependencyCheck -TrustRepository -AcceptLicense
+RUN $null = Install-Module -Name "Microsoft365Dsc" -Repository "PSGallery" -Scope "AllUsers" -Force -SkipPublisherCheck
 RUN $null = Install-PSResource -Name "Pester" -Repository "PSGallery" -Scope "AllUsers" -SkipDependencyCheck -TrustRepository -AcceptLicense
 RUN $null = Install-PSResource -Name "M365DSC.PSDesiredStateConfiguration" -Repository "PSGallery" -Scope "AllUsers" -SkipDependencyCheck -TrustRepository -AcceptLicense
 

--- a/Modules/Microsoft365DSC/Modules/M365DSCGraphShim.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCGraphShim.psm1
@@ -420,7 +420,11 @@ function Invoke-M365DSCGraphShimGetResource
     }
 
     $response = Invoke-M365DSCGraphShimRequest -Method GET -Uri $uri -Headers $requestHeaders -ErrorAction $ErrorActionPreference
-    if ($null -ne $response -and $response -is [hashtable] -and $response.ContainsKey('value'))
+    <#
+        Cmdlet Get-MgBetaDeviceManagementGroupPolicyConfigurationDefinitionValuePresentationValue might return an object with 'value' but we
+        also need the values inside 'presentation' so in that case we must return the whole object inside $response instead of $return.value
+    #>
+    if ($null -ne $response -and $response -is [hashtable] -and $response.ContainsKey('value') -and -not $response.ContainsKey('presentation'))
     {
         return $response.value
     }

--- a/Modules/Microsoft365DSC/Modules/M365DSCGraphShim.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCGraphShim.psm1
@@ -420,11 +420,7 @@ function Invoke-M365DSCGraphShimGetResource
     }
 
     $response = Invoke-M365DSCGraphShimRequest -Method GET -Uri $uri -Headers $requestHeaders -ErrorAction $ErrorActionPreference
-    <#
-        Cmdlet Get-MgBetaDeviceManagementGroupPolicyConfigurationDefinitionValuePresentationValue might return an object with 'value' but we
-        also need the values inside 'presentation' so in that case we must return the whole object inside $response instead of $return.value
-    #>
-    if ($null -ne $response -and $response -is [hashtable] -and $response.ContainsKey('value') -and -not $response.ContainsKey('presentation'))
+    if ($null -ne $response -and $response -is [hashtable] -and $response.ContainsKey('value'))
     {
         return $response.value
     }

--- a/Utilities/New-M365DSCGraphShimModule.ps1
+++ b/Utilities/New-M365DSCGraphShimModule.ps1
@@ -607,10 +607,9 @@ function Invoke-M365DSCGraphShimGetResource
     }
 
     $response = Invoke-M365DSCGraphShimRequest -Method GET -Uri $uri -Headers $requestHeaders -ErrorAction $ErrorActionPreference
-    <#
-        Cmdlet Get-MgBetaDeviceManagementGroupPolicyConfigurationDefinitionValuePresentationValue might return an object with 'value' but we
-        also need the values inside 'presentation' so in that case we must return the whole object inside $response instead of $return.value
-    #>
+
+    # Get-MgBetaDeviceManagementGroupPolicyConfigurationDefinitionValuePresentationValue might return an object with the 'value' property,
+    #  but we also need the values inside 'presentation'. Return the whole object inside $response instead of $response.value
     if ($null -ne $response -and $response -is [hashtable] -and $response.ContainsKey('value') -and -not $response.ContainsKey('presentation'))
     {
         return $response.value

--- a/Utilities/New-M365DSCGraphShimModule.ps1
+++ b/Utilities/New-M365DSCGraphShimModule.ps1
@@ -609,7 +609,7 @@ function Invoke-M365DSCGraphShimGetResource
     $response = Invoke-M365DSCGraphShimRequest -Method GET -Uri $uri -Headers $requestHeaders -ErrorAction $ErrorActionPreference
 
     # Get-MgBetaDeviceManagementGroupPolicyConfigurationDefinitionValuePresentationValue might return an object with the 'value' property,
-    #  but we also need the values inside 'presentation'. Return the whole object inside $response instead of $response.value
+    # but we also need the values inside 'presentation'. Return the whole object inside $response instead of $response.value
     if ($null -ne $response -and $response -is [hashtable] -and $response.ContainsKey('value') -and -not $response.ContainsKey('presentation'))
     {
         return $response.value

--- a/Utilities/New-M365DSCGraphShimModule.ps1
+++ b/Utilities/New-M365DSCGraphShimModule.ps1
@@ -607,7 +607,11 @@ function Invoke-M365DSCGraphShimGetResource
     }
 
     $response = Invoke-M365DSCGraphShimRequest -Method GET -Uri $uri -Headers $requestHeaders -ErrorAction $ErrorActionPreference
-    if ($null -ne $response -and $response -is [hashtable] -and $response.ContainsKey('value'))
+    <#
+        Cmdlet Get-MgBetaDeviceManagementGroupPolicyConfigurationDefinitionValuePresentationValue might return an object with 'value' but we
+        also need the values inside 'presentation' so in that case we must return the whole object inside $response instead of $return.value
+    #>
+    if ($null -ne $response -and $response -is [hashtable] -and $response.ContainsKey('value') -and -not $response.ContainsKey('presentation'))
     {
         return $response.value
     }


### PR DESCRIPTION
#### Pull Request (PR) description

This PR changes the Graph shim on how an object is returned from Graph if both `value` and `presentation` properties are present, this is a workaround required due to resource `IntuneDeviceConfigurationAdministrativeTemplatePolicyWindows10` which might return an object with property `value`, which the shim returns but not anything else but in this case we also require some values inside of `presentation` which due to not being returned are not reachable and the property in this case is not properly exported.

EDIT: This also fixes the build of the Windows docker image.

#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list the issues using a GitHub closing keyword, e.g.:
    - Fixes #123
    - Fixes #124
-->

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take the time to run
    through the below checklist and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that applies to your PR. For those task that
    don't apply to you PR, leave those as is.
-->

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
