### PR TITLE
Make GenerateAlert changeable and not omitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 * IntuneDeviceRemediation
   * Fixed an issue where the `DetectionScriptContent` and `RemediationScriptContent`
     properties were incorrectly converted to a binary array during Set.
+* SCDLPComplianceRule
+  * Updated the `GenerateAlert` property to always export as an array without
+    being omitted from the export.
+    FIXES [#7434](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7434)
 * M365DSCGraphShim
   * Changed how an object is returned from Graph if both `value` and
     `presentation` properties are present. This fixes an issue with the resource

--- a/Modules/Microsoft365DSC/DscResources/MSFT_SCDLPComplianceRule/MSFT_SCDLPComplianceRule.psm1
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_SCDLPComplianceRule/MSFT_SCDLPComplianceRule.psm1
@@ -444,7 +444,7 @@ function Get-TargetResource
             ContentPropertyContainsWords                 = $PolicyRule.ContentPropertyContainsWords
             Disabled                                     = $PolicyRule.Disabled
             Quarantine                                   = $PolicyRule.Quarantine
-            GenerateAlert                                = $PolicyRule.GenerateAlert
+            GenerateAlert                                = Get-M365DSCArrayFromProperty -PropertyValue $PolicyRule.GenerateAlert -ElementType ([System.String])
             GenerateIncidentReport                       = $PolicyRule.GenerateIncidentReport
             IncidentReportContent                        = $ArrayIncidentReportContent
             NotifyAllowOverride                          = $NotifyAllowOverrideValue
@@ -507,18 +507,26 @@ function Get-TargetResource
             AccessTokens                                 = $AccessTokens
         }
 
-        $paramsToRemove = @()
-        foreach ($paramName in $result.Keys)
+        if (-not [System.String]::IsNullOrEmpty($PolicyRule.AdvancedRule))
         {
-            if ($null -eq $result[$paramName] -or '' -eq $result[$paramName] -or @() -eq $result[$paramName])
+            $paramsToRemove = @()
+            foreach ($paramName in $result.Keys)
             {
-                $paramsToRemove += $paramName
-            }
-        }
+                if ($paramName -eq 'GenerateAlert')
+                {
+                    continue
+                }
 
-        foreach ($paramName in $paramsToRemove)
-        {
-            $result.Remove($paramName)
+                if ($null -eq $result[$paramName] -or '' -eq $result[$paramName] -or @() -eq $result[$paramName])
+                {
+                    $paramsToRemove += $paramName
+                }
+            }
+
+            foreach ($paramName in $paramsToRemove)
+            {
+                $result.Remove($paramName)
+            }
         }
 
         return $result


### PR DESCRIPTION
#### Pull Request (PR) description
Make GenerateAlert in `SCDLPComplianceRule` changeable with an empty array and not being omitted. The other "empty" parameters are only omitted if the rule is an advanced rule. If it is not an advanced rule, they are legitimate configuration settings that need being exported.

#### This Pull Request (PR) fixes the following issues
- Fixes #7434 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
